### PR TITLE
Bump ruby version

### DIFF
--- a/roles/discourse/defaults/main.yml
+++ b/roles/discourse/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-rbenv_ruby_version:           "2.0.0-p648"
+rbenv_ruby_version:           "2.3.0"
 
 discourse_hostname:           "discourse.example.com"
 discourse_developer_emails:   ["hello@example.com"]


### PR DESCRIPTION
Discourse minimum version of ruby now is 2.3 , bumped ruby version accordingly
